### PR TITLE
Modified Loading Render-specific message

### DIFF
--- a/src/components/Loading/Loading.tsx
+++ b/src/components/Loading/Loading.tsx
@@ -1,17 +1,29 @@
 function Loading() {
   return (
-    <h1
-      style={{
-        textAlign: "center",
-        color: "blue",
-        borderRadius: "22px",
-        marginTop: "20px",
-        fontFamily: "Fantasy, Arial, Helvetica, sans-serif",
-        fontSize: "44px",
-      }}
-    >
-      LOADING . . .
-    </h1>
+    <>
+      <h1
+        style={{
+          textAlign: "center",
+          color: "blue",
+          borderRadius: "22px",
+          marginTop: "20px",
+          fontFamily: "Fantasy, Arial, Helvetica, sans-serif",
+          fontSize: "44px",
+        }}
+      >
+        LOADING . . .
+      </h1>
+      <h6
+        style={{
+          textAlign: "center",
+          color: "#0DCAF0",
+          fontFamily: "Fantasy, Arial, Helvetica, sans-serif",
+          marginTop: "20px",
+        }}
+      >
+        Kindly await my Server deployed on Render to 'wake up' 😊
+      </h6>
+    </>
   );
 }
 


### PR DESCRIPTION
Added more empathy to the Loading display to show a Render-specific message (free tier taking up to 30s to wake up).