### PR TITLE
Created new Axios instance for avoiding Caches which turned out to be…

### DIFF
--- a/src/hooks/authHooks/useVerifyRefreshTK.ts
+++ b/src/hooks/authHooks/useVerifyRefreshTK.ts
@@ -2,7 +2,10 @@ import axios from "axios";
 import { useDispatchTyped } from "../../redux/reduxCustomTypes/ReduxTypedHooks/typedHooks";
 import { openModalAction } from "../../redux/slices/openModalTextSlice";
 import { authorize, unauthorized } from "../../redux/slices/verifySlice";
-import { axiosCredentials } from "../../utilities/API/axios";
+import {
+  axiosCredentials,
+  axiosCredentialsNonInterceptors,
+} from "../../utilities/API/axios";
 import {
   ErrorUserAuth,
   SuccessUserAuth,
@@ -18,12 +21,52 @@ const useVerifyRefreshTK = (
 ) => {
   const dispatchTyped = useDispatchTyped();
 
+  // const timestamp = Date.now();
+
   if (isUserAuthorized === undefined) {
     const verifyRefreshToken = async () => {
       try {
         // GET /verifyrefreshtoken
-        const { data } = await axiosCredentials.get(
+        const { data } = await axiosCredentialsNonInterceptors.get(
+          // `/api/v1/auth/verifyrefreshtoken${timestamp}`,
           `/api/v1/auth/verifyrefreshtoken`
+          // {
+          //   headers: {
+          //     "Cache-Control": "no-cache",
+          //   },
+          // }
+
+          // NOTE may or may not use these cache headers in the future,
+          // I tried to bypass what turned out to be AVG Chrome bugs
+          // with their new 'Memory save' feature kept sending me
+          // old cookies in the HTTP Requests even when there were
+          // 0 cookies OR: even when I'd re-assign it by document.cookie
+          // the Express.js logs would show it received an
+          // invisible cookie that doesn't exist in the AVG Chrome.
+          // & Checking network tab would show 2 refreshToken cookies
+          // separated by `;` (DUPLICATES inside the HTTP Request: they
+          // were NOT differentiable by anything except their values!
+          // ->Also that first (unwanted) refreshToken's value was being
+          // sent back as Response Header in Set-Cookie & I tried to even
+          // hard-set a different cookie: and result was HTTP Response
+          // gets different cookie BUT AVG Chrome keeps re-sending this
+          // invisible & unwanted bug-inducing cookie), but the
+          // first cookie was stubborn & invisible
+          // and was being sent in every HTTP request
+          // to the /api/v1/auth/verifyrefreshtoken with or without
+          // 'timestamp' and with or without Headers of 'Cache-Control':
+          // 'no cache' & also tests: I tried setting it up
+          // on a button click
+          // same thing happened; however when I moved the controller's
+          // logic
+          // directly to be inside server.ts -> at a simplier /refreshtk
+          // endpoint: it somehow didn't showed that invisible cookie
+          // not on Button click nor by this useVerifyRefreshTK (hm?), but
+          // I couldn't run that endpoint's logic inside server.ts (which
+          // has a lot of codes in it)
+          // just to "avoid" this what-seems-to-be-AVG-Chrome-bug.
+          // HOWEVER: Chrome never has such an unexpected bugs, so AVG
+          // Chrome version was cause of that issue with 100% certainty.
         );
 
         const dataTyped = data as SuccessUserAuth;

--- a/src/utilities/API/axios.ts
+++ b/src/utilities/API/axios.ts
@@ -1,7 +1,7 @@
 import axios, { AxiosError } from "axios";
 
-// const BASE_URL = "http://localhost:3000";
-const BASE_URL = "https://cars-club.netlify.app/api";
+const BASE_URL = "http://localhost:3000";
+// const BASE_URL = "https://cars-club.netlify.app/api";
 
 export const axiosDefaultReq = axios.create({ baseURL: BASE_URL });
 
@@ -12,6 +12,11 @@ export const axiosCredentials = axios.create({
 // NOTE first argument of .post (or .get, etc.) method is 'path',
 // second argument is 'body'/'data' so if third argument ('headers')
 // is needed, then: pass {} to 2nd argument for empty-body requests.
+
+export const axiosCredentialsNonInterceptors = axios.create({
+  baseURL: BASE_URL,
+  withCredentials: true,
+});
 
 export const axiosReqJSON = axios.create({
   baseURL: BASE_URL,


### PR DESCRIPTION
… AVG Chrome bugs sending invisible (old) cookie behind the my eyes & thus breaking my verifyrefreshtoken feature