### PR TITLE
Important bug fix for Render: re-calling verifyRefreshToken 

### DIFF
--- a/src/hooks/authHooks/useVerifyRefreshTK.ts
+++ b/src/hooks/authHooks/useVerifyRefreshTK.ts
@@ -93,6 +93,15 @@ const useVerifyRefreshTK = (
                 },
               })
             );
+            // Fix for sleeping Render.com taking up 30s to wake up
+            if (err?.response?.status === 500) {
+              const id = setTimeout(() => {
+                // It's not infinitive loop because after 30s the server
+                // has already awoke & there's no more 500 Errors.
+                verifyRefreshToken();
+                clearTimeout(id);
+              }, 30003);
+            }
 
             if (routeBelongsTo === "private") {
               dispatchTyped(


### PR DESCRIPTION
Important bug fix for Render: by re-calling verifyRefreshToken itself in a case of status===500 after 30s once the first response was 500 (Server sleeping;) but never again afterwards

&& Thus it's not making any infinitive loops because it only re-calls itself after 30 seconds and ONLY if server is down. IF User closes the browser so and the timer ends (but for the timer inside the response I'm self-removing the 'id').