### PR TITLE
Fixing Render's bugs won't be waking up time EVEN after 30s

### DIFF
--- a/src/hooks/authHooks/useVerifyRefreshTK.ts
+++ b/src/hooks/authHooks/useVerifyRefreshTK.ts
@@ -91,18 +91,27 @@ const useVerifyRefreshTK = (
             err?.response?.status
           );
           if (err?.response?.status === 500) {
-            // Updated5: re-calling verifyRefreshToken() is not enough
-            // status 500 logs, then another 500 arrives; randomly
-            // 2, 3 or 6 calls -> usually with 5s delay it's 'reduced'
-            // to 2 calls but still it seems like Render has sleeping
-            // time (5s+ but 10s? 8s?) after the 30s waking-up time
-            // instead let's use reloads:
-            // window.location.reload(false);
-            // // ^Error: Expected 0 arguments, but got 1.ts
-            // Luckily 'false' is the default so article below was wrong?
-            window.location.reload();
-            // Note: I've also removed the setTimeout and its self-call
-            // to verifyRefreshToken();
+            // Update6: it doesn't work still takes up to 2mins
+            // it took 1:30 minute after I hard refreshed 10 times
+            // CTRL+SHIFT+R
+            // I did try refreshing manually after 30s (receiving 500)
+            // and 10 more times ever after, but STILL it took ~2mins
+            // I'll go back to setTimeout and have it 10s delay.
+            // OTHERWISE I must switch to some paid plans or Fly.io
+            // server left 1/3 but keep Database on Render.com
+
+            // // Updated5: re-calling verifyRefreshToken() is not enough
+            // // status 500 logs, then another 500 arrives; randomly
+            // // 2, 3 or 6 calls -> usually with 5s delay it's 'reduced'
+            // // to 2 calls but still it seems like Render has sleeping
+            // // time (5s+ but 10s? 8s?) after the 30s waking-up time
+            // // instead let's use reloads:
+            // // window.location.reload(false);
+            // // // ^Error: Expected 0 arguments, but got 1.ts
+            // // Luckily 'false' is the default so article below was wrong?
+            // window.location.reload();
+            // // Note: I've also removed the setTimeout and its self-call
+            // // to verifyRefreshToken();
 
             // Update4: 1ms wasn't enough, still took 3 x 500 statuses
             // for 4th request to be of 200
@@ -122,14 +131,15 @@ const useVerifyRefreshTK = (
             // Update2: there's seem to be NO need for timeout because
             // by the time status 500 is received: the Server is UP.
 
-            // const id = setTimeout(() => {
-            //   //   // It's not infinitive loop because after 30s the server
-            //   //   // has already awoke & there's no more 500 Errors.
-            //   verifyRefreshToken();
-            //   clearTimeout(id);
-            //   // }, 30003);
-            //   // }, 1000);
-            // }, 5000);
+            const id = setTimeout(() => {
+              //   // It's not infinitive loop because after 30s the server
+              //   // has already awoke & there's no more 500 Errors.
+              verifyRefreshToken();
+              clearTimeout(id);
+              // }, 30003);
+              // }, 1000);
+              // }, 5000);
+            }, 10000);
           }
 
           if (errDataTyped?.isSuccessful === false) {


### PR DESCRIPTION
It just keeps taking up to 1.5~2mins even with setTimeout (0/1/5/10s) or even with window.location.reload(); It just won't seem to be waking up even with CTRL+SHIFT+R manually refreshing for 10 times AFTER 30s has passed.

Free plans alternatives are Fly.io which I have 1/3 server's left so it means keep Database on Render & Server on Fly.io or let me visit Netlify's updates of "static" server or something like that.