### PR TITLE
Hotfix 2

### DIFF
--- a/src/components/MarketplaceComponents/Post.tsx
+++ b/src/components/MarketplaceComponents/Post.tsx
@@ -307,7 +307,8 @@ function Post() {
                     <textarea
                       id="comment"
                       className="form-control"
-                      rows="3"
+                      // rows="3" // Data type is supposed to be a number.
+                      rows={3}
                       // value={newComment}
                       // onChange={handleCommentChange}
                     ></textarea>

--- a/src/components/MarketplaceComponents/Post.tsx
+++ b/src/components/MarketplaceComponents/Post.tsx
@@ -285,6 +285,39 @@ function Post() {
                   ))}
                 </ul>
               </div> */}
+
+              {/*  */}
+              <div className="comment-section">
+                <h3>Comments</h3>
+                <ul className="list-group">
+                  {/* {comments.map((comment, index) => ( */}
+                  <li
+                    // key={index}
+                    className="list-group-item"
+                  >
+                    {/* {comment} */}
+                  </li>
+                  {/* ))} */}
+                </ul>
+                <form
+                // onSubmit={handleCommentSubmit}
+                >
+                  <div className="form-group">
+                    <label htmlFor="comment">Add a comment:</label>
+                    <textarea
+                      id="comment"
+                      className="form-control"
+                      rows="3"
+                      // value={newComment}
+                      // onChange={handleCommentChange}
+                    ></textarea>
+                  </div>
+                  <button type="submit" className="btn btn-primary">
+                    Submit
+                  </button>
+                </form>
+              </div>
+              {/*  */}
             </div>
           );
         })

--- a/src/hooks/authHooks/useVerifyRefreshTK.ts
+++ b/src/hooks/authHooks/useVerifyRefreshTK.ts
@@ -177,7 +177,12 @@ const useVerifyRefreshTK = (
             }, 10000);
           }
 
-          if (errDataTyped?.isSuccessful === false) {
+          if (
+            errDataTyped?.isSuccessful === false ||
+            // hotfix2.0: if server isn't reachable that's a Network Error:
+            errDataTyped === undefined
+          ) {
+            // return // should not 'return', else openModal isn't triggered
             dispatchTyped(
               unauthorized({
                 userStatus: {
@@ -186,6 +191,13 @@ const useVerifyRefreshTK = (
                 },
               })
             );
+
+            // hotfix2: HEADS-UP: err.message === 'Network Error', but I
+            // won't send a separate dispatch call to open Modal with the correct msg
+            // of the error as to prevent possible hackers of knowing the exact issue
+            // console.log("Initial useVerifyRefreshTK 'err':", err);
+            // console.log("Initial useVerifyRefreshTK errDataTyped:", errDataTyped);
+            // console.log("routeBelongsTo:", routeBelongsTo); // it's 'private'
 
             if (routeBelongsTo === "private") {
               dispatchTyped(


### PR DESCRIPTION
Fixed a bug where the website isn't responsive for the "protected" routes _if the server is shut down_, meaning it will stay at "Loading" screen, instead I've modified `useVerifyRefreshTK.ts` to check whether "**errDataTyped === undefined**" -> then the same `unauthorized` Redux slice (from `verifySlice.tsx`) is triggered(/_dispatched_) for making the Axios API calls.

However, for a UI response to the frontend user I've decided to keep the same _generic message_ in order to avoid giving away too many correct information to a potential hacker (_if the server is attacked AKA shuts down_) => meaning everything else stays the same: it will step over to the `if (routeBelongsTo === "private")` _condition_ (which as a reminder - an already logical fact is that _this condition is **always** truthy because the Hook `useVerifyRefreshTK.ts` is protecting only the "`private`" routes_, but I've kept it as future-feature-proof) which dispatches the same `openModalTextAction` Redux slice/action -> that is: alerting the user with `"Login please!"`.