### PR TITLE
Feature 18 backup2

### DIFF
--- a/src/components/MarketplaceComponents/Post.tsx
+++ b/src/components/MarketplaceComponents/Post.tsx
@@ -288,11 +288,16 @@ function Post() {
 
               {/*  */}
               <div className="comment-section">
-                <h4>Comments</h4>
+                {/* <h4>Comments</h4> */}
                 {/* <h4 className="mt-1">Comments</h4> */}
-                {/* <p className="mt-3" classNmae="fw-bold">
-                  Comments
-                </p> */}
+                <p
+                  // className="mt-1 fw-bold"
+                  className=" fw-bold"
+                  // className="fw-bold"
+                >
+                  Comments:
+                  {/* COMMENTS */}
+                </p>
                 <ul className="list-group">
                   {/* {comments.map((comment, index) => ( */}
                   <li

--- a/src/components/MarketplaceComponents/Post.tsx
+++ b/src/components/MarketplaceComponents/Post.tsx
@@ -289,6 +289,7 @@ function Post() {
               {/*  */}
               <div className="comment-section">
                 {/* <h4>Comments</h4> */}
+                {/* <h6 className="fw-bold">Comments</h6> */}
                 {/* <h4 className="mt-1">Comments</h4> */}
                 <p
                   // className="mt-1 fw-bold"
@@ -320,7 +321,10 @@ function Post() {
                       rows={3}
                       // value={newComment}
                       // onChange={handleCommentChange}
-                    ></textarea>
+                      // >
+                    />
+                    {/* Test text
+                    </textarea> */}
                   </div>
                   <button type="submit" className="btn btn-primary">
                     Submit

--- a/src/components/MarketplaceComponents/Post.tsx
+++ b/src/components/MarketplaceComponents/Post.tsx
@@ -304,10 +304,19 @@ function Post() {
                   <li
                     // key={index}
                     className="list-group-item"
+                    //
+                    // value={post.post_created_by_user_name}
                   >
                     {/* {comment} */}
+                    {/* @ */}
+                    {post.post_created_by_user_name}
                   </li>
                   {/* ))} */}
+                  <li
+                  // className="list-group-item"
+                  >
+                    @Test
+                  </li>
                 </ul>
                 <form
                 // onSubmit={handleCommentSubmit}

--- a/src/components/MarketplaceComponents/Post.tsx
+++ b/src/components/MarketplaceComponents/Post.tsx
@@ -288,7 +288,11 @@ function Post() {
 
               {/*  */}
               <div className="comment-section">
-                <h3>Comments</h3>
+                <h4>Comments</h4>
+                {/* <h4 className="mt-1">Comments</h4> */}
+                {/* <p className="mt-3" classNmae="fw-bold">
+                  Comments
+                </p> */}
                 <ul className="list-group">
                   {/* {comments.map((comment, index) => ( */}
                   <li

--- a/src/components/MarketplaceComponents/Post.tsx
+++ b/src/components/MarketplaceComponents/Post.tsx
@@ -307,7 +307,8 @@ function Post() {
                     <textarea
                       id="comment"
                       className="form-control"
-                      rows="3"
+                      // rows="3" // Data type is supposed to be a number.
+                      rows={3}
                       // value={newComment}
                       // onChange={handleCommentChange}
                     ></textarea>

--- a/src/components/MarketplaceComponents/Post.tsx
+++ b/src/components/MarketplaceComponents/Post.tsx
@@ -285,6 +285,39 @@ function Post() {
                   ))}
                 </ul>
               </div> */}
+
+              {/*  */}
+              <div className="comment-section">
+                <h3>Comments</h3>
+                <ul className="list-group">
+                  {/* {comments.map((comment, index) => ( */}
+                  <li
+                    // key={index}
+                    className="list-group-item"
+                  >
+                    {/* {comment} */}
+                  </li>
+                  {/* ))} */}
+                </ul>
+                <form
+                // onSubmit={handleCommentSubmit}
+                >
+                  <div className="form-group">
+                    <label htmlFor="comment">Add a comment:</label>
+                    <textarea
+                      id="comment"
+                      className="form-control"
+                      rows="3"
+                      // value={newComment}
+                      // onChange={handleCommentChange}
+                    ></textarea>
+                  </div>
+                  <button type="submit" className="btn btn-primary">
+                    Submit
+                  </button>
+                </form>
+              </div>
+              {/*  */}
             </div>
           );
         })


### PR DESCRIPTION
As I'm about to create branch `hotfix3` to fix `FormSearchCars.tsx` state is also inside `Post.tsx` using `useSelector`s (custom `useSelectorTyped`) so that re-renders the heavy JSX of `Post.tsx` and I'd want to ommit them by either not calling `useSelectorTyped` inside of there or else move the `Post.tsx` JSX into 'child' component much deeper inside to avoid JSX re-renders (which is a tips & tricks read somewhere on react.dev).